### PR TITLE
Add SwiftUI MVP app skeleton

### DIFF
--- a/iOSApp/Models/DailyReport.swift
+++ b/iOSApp/Models/DailyReport.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct DailyReport: Identifiable, Hashable {
+    let id: UUID
+    var projectId: UUID
+    var date: Date
+    var summary: String
+    var workforce: String
+    var issues: String
+    var photos: [PhotoAttachment]
+    var createdBy: UserSummary
+}

--- a/iOSApp/Models/Document.swift
+++ b/iOSApp/Models/Document.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct Document: Identifiable, Hashable {
+    enum DocumentType: String, CaseIterable, Codable { case plan, contract, report, photo, checklist, specification }
+
+    let id: UUID
+    var projectId: UUID
+    var taskId: UUID?
+    var name: String
+    var type: DocumentType
+    var url: URL
+    var uploadDate: Date
+    var uploadedBy: UserSummary
+}

--- a/iOSApp/Models/Project.swift
+++ b/iOSApp/Models/Project.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct Project: Identifiable, Hashable {
+    let id: UUID
+    var name: String
+    var client: String
+    var location: String
+    var startDate: Date
+    var endDate: Date?
+    var progress: Double
+    var responsible: UserSummary
+    var tasks: [Task]
+    var dailyReports: [DailyReport]
+    var documents: [Document]
+}
+
+struct UserSummary: Identifiable, Hashable {
+    let id: UUID
+    var name: String
+    var role: String
+}

--- a/iOSApp/Models/Task.swift
+++ b/iOSApp/Models/Task.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct Task: Identifiable, Hashable {
+    enum Status: String, CaseIterable, Codable { case pending, inProgress, completed }
+    enum Priority: String, CaseIterable, Codable { case low, medium, high }
+
+    let id: UUID
+    var projectId: UUID
+    var title: String
+    var description: String
+    var responsible: UserSummary
+    var startDate: Date
+    var dueDate: Date
+    var status: Status
+    var priority: Priority
+    var progress: Double
+    var comments: [Comment]
+    var photos: [PhotoAttachment]
+}
+
+struct Comment: Identifiable, Hashable {
+    let id: UUID
+    var author: UserSummary
+    var message: String
+    var date: Date
+}
+
+struct PhotoAttachment: Identifiable, Hashable {
+    let id: UUID
+    var url: URL
+    var uploadedBy: UserSummary
+    var date: Date
+}

--- a/iOSApp/Models/User.swift
+++ b/iOSApp/Models/User.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct User: Identifiable, Hashable {
+    let id: UUID
+    var name: String
+    var email: String
+    var role: String
+    var notificationsEnabled: Bool
+}

--- a/iOSApp/NotasAIApp.swift
+++ b/iOSApp/NotasAIApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+struct NotasAIApp: App {
+    @StateObject private var authViewModel = AuthViewModel()
+    @StateObject private var projectsViewModel = ProjectsViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            if authViewModel.isAuthenticated {
+                RootView()
+                    .environmentObject(authViewModel)
+                    .environmentObject(projectsViewModel)
+            } else {
+                LoginView()
+                    .environmentObject(authViewModel)
+            }
+        }
+    }
+}

--- a/iOSApp/Services/MockDataService.swift
+++ b/iOSApp/Services/MockDataService.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+final class MockDataService {
+    static let shared = MockDataService()
+
+    let users: [User]
+    private(set) var projects: [Project]
+
+    private init() {
+        let director = User(id: UUID(), name: "Ana Directora", email: "ana@constructora.com", role: "Directora", notificationsEnabled: true)
+        let supervisor = User(id: UUID(), name: "Carlos Supervisor", email: "carlos@constructora.com", role: "Supervisor", notificationsEnabled: true)
+        let contractor = User(id: UUID(), name: "Lucía Contratista", email: "lucia@proveedor.com", role: "Contratista", notificationsEnabled: false)
+        users = [director, supervisor, contractor]
+
+        let directorSummary = UserSummary(id: director.id, name: director.name, role: director.role)
+        let supervisorSummary = UserSummary(id: supervisor.id, name: supervisor.name, role: supervisor.role)
+        let contractorSummary = UserSummary(id: contractor.id, name: contractor.name, role: contractor.role)
+
+        let task1 = Task(
+            id: UUID(),
+            projectId: UUID(),
+            title: "Replanteo de cimentación",
+            description: "Marcar ejes y verificar niveles iniciales.",
+            responsible: supervisorSummary,
+            startDate: Date().addingTimeInterval(-86400 * 3),
+            dueDate: Date().addingTimeInterval(86400 * 4),
+            status: .inProgress,
+            priority: .high,
+            progress: 0.4,
+            comments: [
+                Comment(id: UUID(), author: contractorSummary, message: "Terreno limpio y listo para replanteo", date: Date().addingTimeInterval(-3600 * 18)),
+                Comment(id: UUID(), author: supervisorSummary, message: "Se marca eje norte mañana", date: Date().addingTimeInterval(-3600 * 3))
+            ],
+            photos: []
+        )
+
+        let task2 = Task(
+            id: UUID(),
+            projectId: UUID(),
+            title: "Losas segundo nivel",
+            description: "Colado de losas y revisión de acabados.",
+            responsible: contractorSummary,
+            startDate: Date().addingTimeInterval(-86400 * 10),
+            dueDate: Date().addingTimeInterval(86400 * 2),
+            status: .pending,
+            priority: .medium,
+            progress: 0.15,
+            comments: [],
+            photos: []
+        )
+
+        let report = DailyReport(
+            id: UUID(),
+            projectId: UUID(),
+            date: Date(),
+            summary: "Excavación y armado de zapatas iniciales.",
+            workforce: "2 cuadrillas de 5 personas",
+            issues: "Retraso por lluvia, se protege el área.",
+            photos: [],
+            createdBy: supervisorSummary
+        )
+
+        let document = Document(
+            id: UUID(),
+            projectId: UUID(),
+            taskId: nil,
+            name: "Plano cimentación v3",
+            type: .plan,
+            url: URL(string: "https://example.com/plano.pdf")!,
+            uploadDate: Date().addingTimeInterval(-86400 * 5),
+            uploadedBy: directorSummary
+        )
+
+        let project = Project(
+            id: UUID(),
+            name: "Centro logístico norte",
+            client: "ACME Logistics",
+            location: "Monterrey, MX",
+            startDate: Date().addingTimeInterval(-86400 * 30),
+            endDate: Date().addingTimeInterval(86400 * 120),
+            progress: 0.32,
+            responsible: directorSummary,
+            tasks: [task1, task2],
+            dailyReports: [report],
+            documents: [document]
+        )
+
+        projects = [project]
+    }
+}

--- a/iOSApp/ViewModels/AuthViewModel.swift
+++ b/iOSApp/ViewModels/AuthViewModel.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AuthViewModel: ObservableObject {
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published var isAuthenticated: Bool = false
+    @Published var errorMessage: String?
+    @Published var currentUser: User?
+
+    private let service: MockDataService
+
+    init(service: MockDataService = .shared) {
+        self.service = service
+    }
+
+    func login() {
+        guard !email.isEmpty, !password.isEmpty else {
+            errorMessage = "Ingresa correo y contraseña"
+            return
+        }
+
+        if let user = service.users.first(where: { $0.email.lowercased() == email.lowercased() }) {
+            currentUser = user
+            isAuthenticated = true
+            errorMessage = nil
+        } else {
+            errorMessage = "Credenciales incorrectas"
+            isAuthenticated = false
+        }
+    }
+
+    func logout() {
+        isAuthenticated = false
+        currentUser = nil
+        email = ""
+        password = ""
+    }
+}

--- a/iOSApp/ViewModels/DailyReportViewModel.swift
+++ b/iOSApp/ViewModels/DailyReportViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+@MainActor
+final class DailyReportViewModel: ObservableObject {
+    @Published var reports: [DailyReport]
+    @Published var summary: String = ""
+    @Published var workforce: String = ""
+    @Published var issues: String = ""
+
+    private let projectId: UUID
+    private let author: UserSummary
+
+    init(project: Project, author: UserSummary) {
+        self.projectId = project.id
+        self.author = author
+        self.reports = project.dailyReports
+    }
+
+    func saveReport() {
+        let report = DailyReport(
+            id: UUID(),
+            projectId: projectId,
+            date: Date(),
+            summary: summary,
+            workforce: workforce,
+            issues: issues,
+            photos: [],
+            createdBy: author
+        )
+        reports.insert(report, at: 0)
+        summary = ""
+        workforce = ""
+        issues = ""
+    }
+}

--- a/iOSApp/ViewModels/DocumentListViewModel.swift
+++ b/iOSApp/ViewModels/DocumentListViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@MainActor
+final class DocumentListViewModel: ObservableObject {
+    @Published private(set) var documents: [Document]
+    @Published var searchText: String = ""
+    @Published var selectedType: Document.DocumentType? = nil
+
+    init(documents: [Document]) {
+        self.documents = documents
+    }
+
+    var filteredDocuments: [Document] {
+        documents.filter { document in
+            let matchesType = selectedType == nil || document.type == selectedType
+            let matchesSearch = searchText.isEmpty || document.name.lowercased().contains(searchText.lowercased())
+            return matchesType && matchesSearch
+        }
+    }
+}

--- a/iOSApp/ViewModels/ProjectsViewModel.swift
+++ b/iOSApp/ViewModels/ProjectsViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+@MainActor
+final class ProjectsViewModel: ObservableObject {
+    @Published private(set) var projects: [Project] = []
+    @Published var selectedProject: Project?
+
+    private let service: MockDataService
+
+    init(service: MockDataService = .shared) {
+        self.service = service
+        loadProjects()
+    }
+
+    func loadProjects() {
+        projects = service.projects
+        if selectedProject == nil {
+            selectedProject = projects.first
+        }
+    }
+
+    func refresh() {
+        loadProjects()
+    }
+}

--- a/iOSApp/ViewModels/TaskDetailViewModel.swift
+++ b/iOSApp/ViewModels/TaskDetailViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+@MainActor
+final class TaskDetailViewModel: ObservableObject {
+    @Published private(set) var task: Task
+    @Published var newComment: String = ""
+
+    init(task: Task) {
+        self.task = task
+    }
+
+    func updateStatus(_ status: Task.Status) {
+        task.status = status
+        if status == .completed {
+            task.progress = 1
+        }
+    }
+
+    func updateProgress(_ progress: Double) {
+        task.progress = progress
+        if progress >= 1 { task.status = .completed }
+    }
+
+    func addComment(author: UserSummary) {
+        guard !newComment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let comment = Comment(id: UUID(), author: author, message: newComment, date: Date())
+        task.comments.append(comment)
+        newComment = ""
+    }
+}

--- a/iOSApp/Views/Components/StatusChip.swift
+++ b/iOSApp/Views/Components/StatusChip.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct StatusChip: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(color.opacity(0.15)))
+            .foregroundColor(color)
+    }
+}
+
+struct StatusChip_Previews: PreviewProvider {
+    static var previews: some View {
+        StatusChip(text: "En progreso", color: .blue)
+    }
+}

--- a/iOSApp/Views/DailyReportListView.swift
+++ b/iOSApp/Views/DailyReportListView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct DailyReportListView: View {
+    let project: Project
+    @StateObject private var viewModel: DailyReportViewModel
+
+    init(project: Project) {
+        self.project = project
+        _viewModel = StateObject(wrappedValue: DailyReportViewModel(project: project, author: project.responsible))
+    }
+
+    var body: some View {
+        List {
+            Section("Registrar día") {
+                TextField("Resumen", text: $viewModel.summary)
+                TextField("Mano de obra", text: $viewModel.workforce)
+                TextField("Incidencias", text: $viewModel.issues)
+                Button("Guardar parte") {
+                    viewModel.saveReport()
+                }
+                .disabled(viewModel.summary.isEmpty)
+            }
+
+            Section("Histórico") {
+                ForEach(viewModel.reports) { report in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text(report.date, style: .date)
+                                .bold()
+                            Spacer()
+                            Text(report.createdBy.name)
+                                .font(.caption)
+                        }
+                        Text(report.summary)
+                        if !report.issues.isEmpty {
+                            Label(report.issues, systemImage: "exclamationmark.triangle")
+                                .foregroundStyle(.orange)
+                        }
+                        Label(report.workforce, systemImage: "person.3.fill")
+                            .font(.caption)
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
+        }
+        .navigationTitle("Parte diario")
+    }
+}
+
+struct DailyReportListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            DailyReportListView(project: MockDataService.shared.projects.first!)
+        }
+    }
+}

--- a/iOSApp/Views/DocumentListView.swift
+++ b/iOSApp/Views/DocumentListView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct DocumentListView: View {
+    @StateObject var viewModel: DocumentListViewModel
+
+    var body: some View {
+        List {
+            Section("Filtros") {
+                Picker("Tipo", selection: $viewModel.selectedType) {
+                    Text("Todos").tag(Document.DocumentType?.none)
+                    ForEach(Document.DocumentType.allCases, id: \.self) { type in
+                        Text(type.rawValue.capitalized).tag(Document.DocumentType?.some(type))
+                    }
+                }
+                TextField("Buscar", text: $viewModel.searchText)
+            }
+
+            Section("Documentos") {
+                ForEach(viewModel.filteredDocuments) { document in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text(document.name)
+                                .bold()
+                            Spacer()
+                            Text(document.type.rawValue.capitalized)
+                                .font(.caption)
+                                .padding(6)
+                                .background(Capsule().fill(Color.gray.opacity(0.2)))
+                        }
+                        Text("Subido el \(document.uploadDate.formatted(date: .abbreviated, time: .omitted)) por \(document.uploadedBy.name)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if let host = document.url.host {
+                            Label(host, systemImage: "link")
+                                .font(.caption)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+        .navigationTitle("Documentos")
+    }
+}
+
+struct DocumentListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            DocumentListView(viewModel: DocumentListViewModel(documents: MockDataService.shared.projects.first!.documents))
+        }
+    }
+}

--- a/iOSApp/Views/LoginView.swift
+++ b/iOSApp/Views/LoginView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject private var viewModel: AuthViewModel
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("NotasAI")
+                .font(.largeTitle)
+                .bold()
+
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("Correo", text: $viewModel.email)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                    .padding()
+                    .background(RoundedRectangle(cornerRadius: 12).stroke(Color.gray.opacity(0.2)))
+
+                SecureField("Contraseña", text: $viewModel.password)
+                    .padding()
+                    .background(RoundedRectangle(cornerRadius: 12).stroke(Color.gray.opacity(0.2)))
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .foregroundStyle(.red)
+                        .font(.footnote)
+                }
+
+                Button(action: viewModel.login) {
+                    Text("Iniciar sesión")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(viewModel.email.isEmpty || viewModel.password.isEmpty ? Color.gray.opacity(0.3) : Color.blue)
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .disabled(viewModel.email.isEmpty || viewModel.password.isEmpty)
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+            .environmentObject(AuthViewModel())
+    }
+}

--- a/iOSApp/Views/ProjectDetailView.swift
+++ b/iOSApp/Views/ProjectDetailView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ProjectDetailView: View {
+    let project: Project
+
+    var body: some View {
+        List {
+            Section("Resumen") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(project.name)
+                        .font(.title3)
+                        .bold()
+                    Text("Cliente: \(project.client)")
+                    Text("Ubicación: \(project.location)")
+                    Text("Responsable: \(project.responsible.name)")
+                    ProgressView("Progreso general", value: project.progress)
+                        .tint(.blue)
+                }
+            }
+
+            Section("Módulos") {
+                NavigationLink(destination: TaskListView(project: project)) {
+                    Label("Tareas", systemImage: "checklist")
+                }
+                NavigationLink(destination: DailyReportListView(project: project)) {
+                    Label("Parte diario", systemImage: "calendar.badge.clock")
+                }
+                NavigationLink(destination: DocumentListView(viewModel: DocumentListViewModel(documents: project.documents))) {
+                    Label("Documentos", systemImage: "doc.text")
+                }
+            }
+        }
+        .navigationTitle("Proyecto")
+    }
+}
+
+struct ProjectDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            ProjectDetailView(project: MockDataService.shared.projects.first!)
+        }
+    }
+}

--- a/iOSApp/Views/ProjectListView.swift
+++ b/iOSApp/Views/ProjectListView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct ProjectListView<Destination: View>: View {
+    let projects: [Project]
+    let destination: (Project) -> Destination
+
+    var body: some View {
+        List(projects) { project in
+            NavigationLink(value: project) {
+                ProjectRow(project: project)
+            }
+            .navigationDestination(for: Project.self) { project in
+                destination(project)
+            }
+        }
+    }
+}
+
+private struct ProjectRow: View {
+    let project: Project
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(project.name)
+                    .font(.headline)
+                Spacer()
+                Text("\(Int(project.progress * 100))%")
+                    .font(.caption)
+                    .padding(6)
+                    .background(Capsule().fill(Color.blue.opacity(0.1)))
+            }
+            Text(project.client)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            HStack {
+                Label(project.location, systemImage: "mappin.and.ellipse")
+                Spacer()
+                Label(project.responsible.name, systemImage: "person.fill")
+            }
+            .font(.caption)
+            ProgressView(value: project.progress)
+                .tint(.blue)
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+struct ProjectListView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProjectListView(projects: MockDataService.shared.projects, destination: { _ in Text("Detalle") })
+    }
+}

--- a/iOSApp/Views/RootView.swift
+++ b/iOSApp/Views/RootView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var authViewModel: AuthViewModel
+    @EnvironmentObject private var projectsViewModel: ProjectsViewModel
+
+    var body: some View {
+        NavigationStack {
+            ProjectListView(projects: projectsViewModel.projects) { project in
+                ProjectDetailView(project: project)
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cerrar sesión") {
+                        authViewModel.logout()
+                    }
+                }
+            }
+            .navigationTitle("Proyectos")
+        }
+    }
+}
+
+struct RootView_Previews: PreviewProvider {
+    static var previews: some View {
+        RootView()
+            .environmentObject(AuthViewModel())
+            .environmentObject(ProjectsViewModel())
+    }
+}

--- a/iOSApp/Views/TaskDetailView.swift
+++ b/iOSApp/Views/TaskDetailView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct TaskDetailView: View {
+    @StateObject private var viewModel: TaskDetailViewModel
+    let project: Project
+
+    init(task: Task, project: Project) {
+        _viewModel = StateObject(wrappedValue: TaskDetailViewModel(task: task))
+        self.project = project
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(viewModel.task.title)
+                            .font(.title2)
+                            .bold()
+                        Spacer()
+                        StatusChip(text: label(for: viewModel.task.status), color: color(for: viewModel.task.status))
+                    }
+                    Text(viewModel.task.description)
+                        .foregroundStyle(.secondary)
+                }
+
+                GroupBox("Información") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Responsable: \(viewModel.task.responsible.name)", systemImage: "person.fill")
+                        Label("Inicio: \(viewModel.task.startDate.formatted(date: .abbreviated, time: .omitted))", systemImage: "calendar")
+                        Label("Vence: \(viewModel.task.dueDate.formatted(date: .abbreviated, time: .omitted))", systemImage: "clock")
+                        Label("Prioridad: \(viewModel.task.priority.rawValue.capitalized)", systemImage: "flag.fill")
+                    }
+                }
+
+                GroupBox("Progreso") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Slider(value: Binding(
+                            get: { viewModel.task.progress },
+                            set: { viewModel.updateProgress($0) }
+                        ), in: 0...1)
+                        Text("Avance: \(Int(viewModel.task.progress * 100))%")
+                        HStack {
+                            Button("Pendiente") { viewModel.updateStatus(.pending) }
+                            Button("En progreso") { viewModel.updateStatus(.inProgress) }
+                            Button("Finalizar") { viewModel.updateStatus(.completed) }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    }
+                }
+
+                GroupBox("Comentarios") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        ForEach(viewModel.task.comments) { comment in
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Text(comment.author.name)
+                                        .bold()
+                                    Spacer()
+                                    Text(comment.date, style: .time)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(comment.message)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        Divider()
+                        HStack {
+                            TextField("Añadir comentario", text: $viewModel.newComment)
+                            Button(action: {
+                                viewModel.addComment(author: project.responsible)
+                            }) {
+                                Image(systemName: "paperplane.fill")
+                            }
+                            .disabled(viewModel.newComment.isEmpty)
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Detalle")
+    }
+
+    private func label(for status: Task.Status) -> String {
+        switch status {
+        case .pending: "Pendiente"
+        case .inProgress: "En progreso"
+        case .completed: "Finalizada"
+        }
+    }
+
+    private func color(for status: Task.Status) -> Color {
+        switch status {
+        case .pending: .gray
+        case .inProgress: .blue
+        case .completed: .green
+        }
+    }
+}
+
+struct TaskDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            TaskDetailView(task: MockDataService.shared.projects.first!.tasks.first!, project: MockDataService.shared.projects.first!)
+        }
+    }
+}

--- a/iOSApp/Views/TaskListView.swift
+++ b/iOSApp/Views/TaskListView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct TaskListView: View {
+    let project: Project
+
+    var body: some View {
+        List(project.tasks) { task in
+            NavigationLink(destination: TaskDetailView(task: task, project: project)) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(task.title)
+                            .font(.headline)
+                        Spacer()
+                        StatusChip(text: label(for: task.status), color: color(for: task.status))
+                    }
+                    Text(task.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        Label(task.responsible.name, systemImage: "person.fill")
+                        Spacer()
+                        Label(task.dueDate, style: .date)
+                    }
+                    .font(.caption)
+                    ProgressView(value: task.progress)
+                        .tint(.blue)
+                }
+                .padding(.vertical, 6)
+            }
+        }
+        .navigationTitle("Tareas")
+    }
+
+    private func label(for status: Task.Status) -> String {
+        switch status {
+        case .pending: "Pendiente"
+        case .inProgress: "En progreso"
+        case .completed: "Finalizada"
+        }
+    }
+
+    private func color(for status: Task.Status) -> Color {
+        switch status {
+        case .pending: .gray
+        case .inProgress: .blue
+        case .completed: .green
+        }
+    }
+}
+
+struct TaskListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            TaskListView(project: MockDataService.shared.projects.first!)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI entry point with login gate and project navigation
- scaffold views for projects, tareas, partes diarios y documentos basados en los docs
- incluir modelos, view models y datos de ejemplo para flujos del MVP

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692c636dc040832f8dd749a9fb009d18)