### PR TITLE
Enhance task UX with filtering and creation

### DIFF
--- a/iOSApp/ViewModels/TaskDetailViewModel.swift
+++ b/iOSApp/ViewModels/TaskDetailViewModel.swift
@@ -4,9 +4,11 @@ import Foundation
 final class TaskDetailViewModel: ObservableObject {
     @Published private(set) var task: Task
     @Published var newComment: String = ""
+    private let onUpdate: (Task) -> Void
 
-    init(task: Task) {
+    init(task: Task, onUpdate: @escaping (Task) -> Void) {
         self.task = task
+        self.onUpdate = onUpdate
     }
 
     func updateStatus(_ status: Task.Status) {
@@ -14,11 +16,13 @@ final class TaskDetailViewModel: ObservableObject {
         if status == .completed {
             task.progress = 1
         }
+        onUpdate(task)
     }
 
     func updateProgress(_ progress: Double) {
         task.progress = progress
         if progress >= 1 { task.status = .completed }
+        onUpdate(task)
     }
 
     func addComment(author: UserSummary) {
@@ -26,5 +30,13 @@ final class TaskDetailViewModel: ObservableObject {
         let comment = Comment(id: UUID(), author: author, message: newComment, date: Date())
         task.comments.append(comment)
         newComment = ""
+        onUpdate(task)
+    }
+
+    func addPhotoAttachment(by author: UserSummary) {
+        let sampleURL = URL(string: "https://picsum.photos/200")!
+        let attachment = PhotoAttachment(id: UUID(), url: sampleURL, uploadedBy: author, date: Date())
+        task.photos.append(attachment)
+        onUpdate(task)
     }
 }

--- a/iOSApp/ViewModels/TaskListViewModel.swift
+++ b/iOSApp/ViewModels/TaskListViewModel.swift
@@ -1,0 +1,122 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class TaskListViewModel: ObservableObject {
+    enum SortOption: String, CaseIterable { case dueDate, priority, status }
+
+    @Published private(set) var tasks: [Task]
+    @Published var searchText: String = ""
+    @Published var statusFilter: Task.Status?
+    @Published var sortOption: SortOption = .dueDate
+    @Published var isPresentingNewTask: Bool = false
+    @Published var draft: TaskDraft
+    @Published var validationMessage: String?
+
+    init(project: Project) {
+        self.tasks = project.tasks
+        self.draft = TaskDraft(responsible: project.responsible, projectId: project.id)
+    }
+
+    var filteredTasks: [Task] {
+        var result = tasks
+
+        if let status = statusFilter {
+            result = result.filter { $0.status == status }
+        }
+
+        if !searchText.isEmpty {
+            result = result.filter { task in
+                task.title.localizedCaseInsensitiveContains(searchText) ||
+                task.description.localizedCaseInsensitiveContains(searchText) ||
+                task.responsible.name.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+
+        switch sortOption {
+        case .dueDate:
+            result = result.sorted { $0.dueDate < $1.dueDate }
+        case .priority:
+            result = result.sorted { $0.priority.sortWeight > $1.priority.sortWeight }
+        case .status:
+            result = result.sorted { $0.status.sortWeight < $1.status.sortWeight }
+        }
+
+        return result
+    }
+
+    func updateTask(_ task: Task) {
+        guard let index = tasks.firstIndex(where: { $0.id == task.id }) else { return }
+        tasks[index] = task
+    }
+
+    func resetDraft(for project: Project) {
+        draft = TaskDraft(responsible: project.responsible, projectId: project.id)
+        validationMessage = nil
+    }
+
+    func createTask(for project: Project) -> Bool {
+        guard let task = draft.build() else {
+            validationMessage = "Completa los campos obligatorios y valida fechas."
+            return false
+        }
+        tasks.append(task)
+        return true
+    }
+}
+
+struct TaskDraft {
+    var projectId: UUID
+    var title: String = ""
+    var description: String = ""
+    var responsible: UserSummary
+    var startDate: Date = Date()
+    var dueDate: Date = Date().addingTimeInterval(86400)
+    var priority: Task.Priority = .medium
+
+    init(responsible: UserSummary, projectId: UUID) {
+        self.responsible = responsible
+        self.projectId = projectId
+    }
+
+    func build() -> Task? {
+        guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              dueDate >= startDate else { return nil }
+
+        return Task(
+            id: UUID(),
+            projectId: projectId,
+            title: title,
+            description: description,
+            responsible: responsible,
+            startDate: startDate,
+            dueDate: dueDate,
+            status: .pending,
+            priority: priority,
+            progress: 0,
+            comments: [],
+            photos: []
+        )
+    }
+}
+
+private extension Task.Priority {
+    var sortWeight: Int {
+        switch self {
+        case .high: 2
+        case .medium: 1
+        case .low: 0
+        }
+    }
+}
+
+private extension Task.Status {
+    var sortWeight: Int {
+        switch self {
+        case .pending: 0
+        case .inProgress: 1
+        case .completed: 2
+        }
+    }
+}

--- a/iOSApp/Views/TaskListView.swift
+++ b/iOSApp/Views/TaskListView.swift
@@ -2,33 +2,91 @@ import SwiftUI
 
 struct TaskListView: View {
     let project: Project
+    @StateObject private var viewModel: TaskListViewModel
+
+    init(project: Project) {
+        self.project = project
+        _viewModel = StateObject(wrappedValue: TaskListViewModel(project: project))
+    }
 
     var body: some View {
-        List(project.tasks) { task in
-            NavigationLink(destination: TaskDetailView(task: task, project: project)) {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text(task.title)
-                            .font(.headline)
-                        Spacer()
-                        StatusChip(text: label(for: task.status), color: color(for: task.status))
+        List {
+            if viewModel.filteredTasks.isEmpty {
+                ContentUnavailableView("Sin tareas", systemImage: "checklist.unchecked", description: Text("Crea la primera tarea para este proyecto"))
+            } else {
+                ForEach(viewModel.filteredTasks) { task in
+                    NavigationLink(destination: TaskDetailView(task: task, project: project) { updated in
+                        viewModel.updateTask(updated)
+                    }) {
+                        taskRow(task)
                     }
-                    Text(task.description)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    HStack {
-                        Label(task.responsible.name, systemImage: "person.fill")
-                        Spacer()
-                        Label(task.dueDate, style: .date)
-                    }
-                    .font(.caption)
-                    ProgressView(value: task.progress)
-                        .tint(.blue)
                 }
-                .padding(.vertical, 6)
             }
         }
+        .listStyle(.insetGrouped)
         .navigationTitle("Tareas")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    viewModel.resetDraft(for: project)
+                    viewModel.isPresentingNewTask = true
+                } label: {
+                    Label("Nueva tarea", systemImage: "plus")
+                }
+            }
+            ToolbarItemGroup(placement: .bottomBar) {
+                Picker("Estado", selection: Binding<Task.Status?>(
+                    get: { viewModel.statusFilter },
+                    set: { newValue in viewModel.statusFilter = newValue }
+                )) {
+                    Text("Todos").tag(Task.Status?.none)
+                    ForEach(Task.Status.allCases, id: \.self) { status in
+                        Text(label(for: status)).tag(Optional(status))
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Menu {
+                    Picker("Orden", selection: $viewModel.sortOption) {
+                        ForEach(TaskListViewModel.SortOption.allCases, id: \.self) { option in
+                            Label(title(for: option), systemImage: icon(for: option)).tag(option)
+                        }
+                    }
+                } label: {
+                    Label("Ordenar", systemImage: "arrow.up.arrow.down")
+                }
+            }
+        }
+        .searchable(text: $viewModel.searchText, prompt: "Buscar por título, descripción o responsable")
+        .sheet(isPresented: $viewModel.isPresentingNewTask) {
+            NavigationStack {
+                TaskCreationView(viewModel: viewModel, project: project)
+            }
+            .presentationDetents([.large])
+        }
+    }
+
+    private func taskRow(_ task: Task) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(task.title)
+                    .font(.headline)
+                Spacer()
+                StatusChip(text: label(for: task.status), color: color(for: task.status))
+            }
+            Text(task.description)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            HStack {
+                Label(task.responsible.name, systemImage: "person.fill")
+                Spacer()
+                Label(task.dueDate, style: .date)
+            }
+            .font(.caption)
+            ProgressView(value: task.progress)
+                .tint(.blue)
+        }
+        .padding(.vertical, 6)
     }
 
     private func label(for status: Task.Status) -> String {
@@ -44,6 +102,74 @@ struct TaskListView: View {
         case .pending: .gray
         case .inProgress: .blue
         case .completed: .green
+        }
+    }
+
+    private func title(for option: TaskListViewModel.SortOption) -> String {
+        switch option {
+        case .dueDate: "Fecha de vencimiento"
+        case .priority: "Prioridad"
+        case .status: "Estado"
+        }
+    }
+
+    private func icon(for option: TaskListViewModel.SortOption) -> String {
+        switch option {
+        case .dueDate: return "calendar"
+        case .priority: return "flag.fill"
+        case .status: return "checkmark.circle"
+        }
+    }
+}
+
+struct TaskCreationView: View {
+    @ObservedObject var viewModel: TaskListViewModel
+    let project: Project
+
+    var body: some View {
+        Form {
+            Section("Detalles") {
+                TextField("Título *", text: $viewModel.draft.title)
+                TextField("Descripción *", text: $viewModel.draft.description, axis: .vertical)
+                Picker("Prioridad", selection: $viewModel.draft.priority) {
+                    Text("Alta").tag(Task.Priority.high)
+                    Text("Media").tag(Task.Priority.medium)
+                    Text("Baja").tag(Task.Priority.low)
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section("Responsable") {
+                Text(viewModel.draft.responsible.name)
+                Text(viewModel.draft.responsible.role)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Fechas") {
+                DatePicker("Inicio", selection: $viewModel.draft.startDate, displayedComponents: .date)
+                DatePicker("Vence *", selection: $viewModel.draft.dueDate, in: viewModel.draft.startDate..., displayedComponents: .date)
+            }
+
+            if let validation = viewModel.validationMessage {
+                Section {
+                    Label(validation, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                }
+            }
+        }
+        .navigationTitle("Nueva tarea")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancelar") { viewModel.isPresentingNewTask = false }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Crear") {
+                    if viewModel.createTask(for: project) {
+                        viewModel.isPresentingNewTask = false
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add task list filtering, sorting, search, and a validated creation form
- sync task detail edits back to the list including status, progress, comments, and photo attachments
- style comments as chat bubbles and surface photo attachment previews

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692c6518418c832f95f571c99d920547)