### PR TITLE
Add daily report creation with photos and notifications

### DIFF
--- a/iOSApp/Services/MockDataService.swift
+++ b/iOSApp/Services/MockDataService.swift
@@ -15,10 +15,11 @@ final class MockDataService {
         let directorSummary = UserSummary(id: director.id, name: director.name, role: director.role)
         let supervisorSummary = UserSummary(id: supervisor.id, name: supervisor.name, role: supervisor.role)
         let contractorSummary = UserSummary(id: contractor.id, name: contractor.name, role: contractor.role)
+        let projectUUID = UUID()
 
         let task1 = Task(
             id: UUID(),
-            projectId: UUID(),
+            projectId: projectUUID,
             title: "Replanteo de cimentación",
             description: "Marcar ejes y verificar niveles iniciales.",
             responsible: supervisorSummary,
@@ -36,7 +37,7 @@ final class MockDataService {
 
         let task2 = Task(
             id: UUID(),
-            projectId: UUID(),
+            projectId: projectUUID,
             title: "Losas segundo nivel",
             description: "Colado de losas y revisión de acabados.",
             responsible: contractorSummary,
@@ -49,20 +50,32 @@ final class MockDataService {
             photos: []
         )
 
+        let reportPhoto = PhotoAttachment(id: UUID(), url: URL(string: "https://picsum.photos/300")!, uploadedBy: supervisorSummary, date: Date().addingTimeInterval(-3600 * 5))
         let report = DailyReport(
             id: UUID(),
-            projectId: UUID(),
-            date: Date(),
+            projectId: projectUUID,
+            date: Date().addingTimeInterval(-86400),
             summary: "Excavación y armado de zapatas iniciales.",
             workforce: "2 cuadrillas de 5 personas",
             issues: "Retraso por lluvia, se protege el área.",
+            photos: [reportPhoto],
+            createdBy: supervisorSummary
+        )
+
+        let olderReport = DailyReport(
+            id: UUID(),
+            projectId: projectUUID,
+            date: Date().addingTimeInterval(-86400 * 3),
+            summary: "Revisión de accesos y cercado perimetral.",
+            workforce: "1 cuadrilla de 4 personas",
+            issues: "Sin incidencias.",
             photos: [],
             createdBy: supervisorSummary
         )
 
         let document = Document(
             id: UUID(),
-            projectId: UUID(),
+            projectId: projectUUID,
             taskId: nil,
             name: "Plano cimentación v3",
             type: .plan,
@@ -72,7 +85,7 @@ final class MockDataService {
         )
 
         let project = Project(
-            id: UUID(),
+            id: projectUUID,
             name: "Centro logístico norte",
             client: "ACME Logistics",
             location: "Monterrey, MX",
@@ -81,7 +94,7 @@ final class MockDataService {
             progress: 0.32,
             responsible: directorSummary,
             tasks: [task1, task2],
-            dailyReports: [report],
+            dailyReports: [report, olderReport],
             documents: [document]
         )
 

--- a/iOSApp/ViewModels/DailyReportViewModel.swift
+++ b/iOSApp/ViewModels/DailyReportViewModel.swift
@@ -6,14 +6,18 @@ final class DailyReportViewModel: ObservableObject {
     @Published var summary: String = ""
     @Published var workforce: String = ""
     @Published var issues: String = ""
+    @Published var attachedPhotos: [PhotoAttachment] = []
+    @Published var lastNotification: String? = nil
 
     private let projectId: UUID
     private let author: UserSummary
+    private let director: UserSummary
 
     init(project: Project, author: UserSummary) {
         self.projectId = project.id
         self.author = author
-        self.reports = project.dailyReports
+        self.director = project.responsible
+        self.reports = project.dailyReports.sorted { $0.date > $1.date }
     }
 
     func saveReport() {
@@ -24,12 +28,21 @@ final class DailyReportViewModel: ObservableObject {
             summary: summary,
             workforce: workforce,
             issues: issues,
-            photos: [],
+            photos: attachedPhotos,
             createdBy: author
         )
-        reports.insert(report, at: 0)
+        reports.append(report)
+        reports.sort { $0.date > $1.date }
+        attachedPhotos.removeAll()
         summary = ""
         workforce = ""
         issues = ""
+        lastNotification = "Notificación enviada a \(director.name)"
+    }
+
+    func addPhotoAttachment() {
+        let sampleURL = URL(string: "https://picsum.photos/200")!
+        let attachment = PhotoAttachment(id: UUID(), url: sampleURL, uploadedBy: author, date: Date())
+        attachedPhotos.append(attachment)
     }
 }

--- a/iOSApp/Views/DailyReportListView.swift
+++ b/iOSApp/Views/DailyReportListView.swift
@@ -15,10 +15,58 @@ struct DailyReportListView: View {
                 TextField("Resumen", text: $viewModel.summary)
                 TextField("Mano de obra", text: $viewModel.workforce)
                 TextField("Incidencias", text: $viewModel.issues)
+                HStack {
+                    Label {
+                        Text(Date(), style: .date)
+                    } icon: {
+                        Image(systemName: "calendar")
+                    }
+                    .font(.caption)
+                    Spacer()
+                    Label("Se notificará a \(project.responsible.name)", systemImage: "bell")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(viewModel.attachedPhotos) { photo in
+                            AsyncImage(url: photo.url) { image in
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                            } placeholder: {
+                                ProgressView()
+                            }
+                            .frame(width: 80, height: 80)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .overlay(alignment: .bottomLeading) {
+                                Label(photo.uploadedBy.name, systemImage: "person.fill")
+                                    .font(.caption2)
+                                    .padding(6)
+                                    .background(.ultraThinMaterial, in: Capsule())
+                                    .padding(4)
+                            }
+                        }
+                        Button {
+                            viewModel.addPhotoAttachment()
+                        } label: {
+                            Label("Añadir foto", systemImage: "camera.fill")
+                                .frame(width: 110, height: 80)
+                                .background(Color.blue.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
                 Button("Guardar parte") {
                     viewModel.saveReport()
                 }
                 .disabled(viewModel.summary.isEmpty)
+            }
+            if let notification = viewModel.lastNotification {
+                Section {
+                    Label(notification, systemImage: "bell.badge")
+                        .foregroundStyle(.green)
+                }
             }
 
             Section("Histórico") {
@@ -38,6 +86,30 @@ struct DailyReportListView: View {
                         }
                         Label(report.workforce, systemImage: "person.3.fill")
                             .font(.caption)
+                        if !report.photos.isEmpty {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 10) {
+                                    ForEach(report.photos) { photo in
+                                        AsyncImage(url: photo.url) { image in
+                                            image
+                                                .resizable()
+                                                .scaledToFill()
+                                        } placeholder: {
+                                            ProgressView()
+                                        }
+                                        .frame(width: 80, height: 80)
+                                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                                        .overlay(alignment: .bottomTrailing) {
+                                            Label(photo.uploadedBy.name, systemImage: "person.fill")
+                                                .font(.caption2)
+                                                .padding(4)
+                                                .background(.ultraThinMaterial, in: Capsule())
+                                                .padding(4)
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                     .padding(.vertical, 6)
                 }


### PR DESCRIPTION
## Summary
- add photo attachment flow and notification feedback when creating daily reports
- sort daily report history by date and display attached images inline
- refresh mock data to include project-linked identifiers and multiple sample daily reports

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692c74f0edc8832f9f18955e53d6b391)