### PR TITLE
Add password validation for mock login

### DIFF
--- a/iOSApp/Models/User.swift
+++ b/iOSApp/Models/User.swift
@@ -5,5 +5,6 @@ struct User: Identifiable, Hashable {
     var name: String
     var email: String
     var role: String
+    var password: String
     var notificationsEnabled: Bool
 }

--- a/iOSApp/Services/MockDataService.swift
+++ b/iOSApp/Services/MockDataService.swift
@@ -7,9 +7,9 @@ final class MockDataService {
     private(set) var projects: [Project]
 
     private init() {
-        let director = User(id: UUID(), name: "Ana Directora", email: "ana@constructora.com", role: "Directora", notificationsEnabled: true)
-        let supervisor = User(id: UUID(), name: "Carlos Supervisor", email: "carlos@constructora.com", role: "Supervisor", notificationsEnabled: true)
-        let contractor = User(id: UUID(), name: "Lucía Contratista", email: "lucia@proveedor.com", role: "Contratista", notificationsEnabled: false)
+        let director = User(id: UUID(), name: "Ana Directora", email: "ana@constructora.com", role: "Directora", password: "director123", notificationsEnabled: true)
+        let supervisor = User(id: UUID(), name: "Carlos Supervisor", email: "carlos@constructora.com", role: "Supervisor", password: "supervisor123", notificationsEnabled: true)
+        let contractor = User(id: UUID(), name: "Lucía Contratista", email: "lucia@proveedor.com", role: "Contratista", password: "proveedor123", notificationsEnabled: false)
         users = [director, supervisor, contractor]
 
         let directorSummary = UserSummary(id: director.id, name: director.name, role: director.role)

--- a/iOSApp/ViewModels/AuthViewModel.swift
+++ b/iOSApp/ViewModels/AuthViewModel.swift
@@ -21,14 +21,21 @@ final class AuthViewModel: ObservableObject {
             return
         }
 
-        if let user = service.users.first(where: { $0.email.lowercased() == email.lowercased() }) {
-            currentUser = user
-            isAuthenticated = true
-            errorMessage = nil
-        } else {
-            errorMessage = "Credenciales incorrectas"
+        guard let user = service.users.first(where: { $0.email.lowercased() == email.lowercased() }) else {
+            errorMessage = "Usuario no registrado"
             isAuthenticated = false
+            return
         }
+
+        guard user.password == password else {
+            errorMessage = "Contraseña incorrecta"
+            isAuthenticated = false
+            return
+        }
+
+        currentUser = user
+        isAuthenticated = true
+        errorMessage = nil
     }
 
     func logout() {


### PR DESCRIPTION
## Summary
- add a password field to the user model and mock service seed data
- require matching email and password when logging in, with clearer error messages

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692c78fe6ae4832fb0e8884fabd8408f)